### PR TITLE
Squashed bringup of vendor sepolicy for M

### DIFF
--- a/prebuilt/common/etc/init.local.rc
+++ b/prebuilt/common/etc/init.local.rc
@@ -11,6 +11,7 @@ on boot
     start sysinit
     chown system system /sys/block/mmcblk0/queue/scheduler
     chmod 0664 /sys/block/mmcblk0/queue/scheduler
+    restorecon /sys/block/mmcblk0/queue/scheduler
 
 # allow system to modify ksm control files
     chown root system /sys/kernel/mm/ksm/pages_to_scan
@@ -25,7 +26,11 @@ on boot
     chown system system /dev/cpuctl/apps/cpu.notify_on_migrate
     chmod 0644 /dev/cpuctl/apps/cpu.notify_on_migrate
 
+    # Persistent properties (only created if persist exists)
+    mkdir /persist/properties 0770 system system
+
 # adb over network
+
 on property:service.adb.tcp.port=5555
     stop adbd
     start adbd

--- a/sepolicy/adbd.te
+++ b/sepolicy/adbd.te
@@ -1,1 +1,0 @@
-allow adbd adbtcp_prop:property_service set;

--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -6,8 +6,14 @@ type auditd_log, file_type, data_file_type;
 # Themes
 type theme_data_file, file_type, data_file_type;
 
+# Performance settings
+type sysfs_devices_system_iosched, file_type, sysfs_type;
+
 # Recovery's "cache"
 type recovery_cache_file, file_type, mlstrustedobject;
 
 # Persistent property storage
 type persist_property_file, file_type;
+
+# Knobs for LiveDisplay
+type livedisplay_sysfs, sysfs_type, file_type;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -41,6 +41,12 @@
 # Persistent properties
 /persist/properties(/.*)?         u:object_r:persist_property_file:s0
 
+# LiveDisplay
+/sys/devices/virtual/graphics/fb0/aco           u:object_r:livedisplay_sysfs:s0
+/sys/devices/virtual/graphics/fb0/cabc          u:object_r:livedisplay_sysfs:s0
+/sys/devices/virtual/graphics/fb0/rgb           u:object_r:livedisplay_sysfs:s0
+/sys/devices/virtual/graphics/fb0/sre           u:object_r:livedisplay_sysfs:s0
+
 # fsck
 /system/bin/fsck\.ntfs                          u:object_r:fsck_exec:s0
 /system/bin/fsck\.exfat                         u:object_r:fsck_exec:s0

--- a/sepolicy/fsck_untrusted.te
+++ b/sepolicy/fsck_untrusted.te
@@ -1,0 +1,2 @@
+# External storage
+allow fsck_untrusted self:capability sys_admin;

--- a/sepolicy/genfs_contexts
+++ b/sepolicy/genfs_contexts
@@ -1,1 +1,3 @@
 genfscon fuseblk / u:object_r:sdcard_external:s0
+genfscon exfat / u:object_r:sdcard_external:s0
+genfscon ntfs / u:object_r:sdcard_external:s0

--- a/sepolicy/livedisplay.te
+++ b/sepolicy/livedisplay.te
@@ -1,0 +1,2 @@
+# Various knobs used by LiveDisplay
+allow system_server livedisplay_sysfs:file rw_file_perms;

--- a/sepolicy/mac_permissions.xml
+++ b/sepolicy/mac_permissions.xml
@@ -14,4 +14,11 @@
     <allow-all />
     <seinfo value="release" />
   </signer>
+
+  <!-- CMUpdater -->
+  <signer signature="@RELEASE" >
+    <package name="com.cyanogenmod.updater" >
+      <seinfo value="cmupdater" />
+    </package>
+  </signer>
 </policy>

--- a/sepolicy/property_contexts
+++ b/sepolicy/property_contexts
@@ -1,3 +1,4 @@
 adb.network.port              u:object_r:adbtcp_prop:s0
 recovery.perf.mode            u:object_r:recovery_prop:s0
 adb.secure                    u:object_r:recovery_prop:s0
+cm.userinit.active            u:object_r:userinit_prop:s0

--- a/sepolicy/qcom/adbd.c
+++ b/sepolicy/qcom/adbd.c
@@ -1,0 +1,14 @@
+# Allow pulling various binaries without root
+# (cause we're awesome like that)
+
+allow adbd adsprpcd_exec:file r_file_perms;
+allow adbd location_exec:file r_file_perms;
+allow adbd mm-qcamerad_exec:file r_file_perms;
+allow adbd mpdecision_exec:file r_file_perms;
+allow adbd perfd_exec:file r_file_perms;
+allow adbd rfs_access_exec:file r_file_perms;
+allow adbd rmt_storage_exec:file r_file_perms;
+allow adbd sensors_exec:file r_file_perms;
+allow adbd tee_exec:file r_file_perms;
+allow adbd thermal-engine_exec:file r_file_perms;
+allow adbd time_daemon_exec:file r_file_perms;

--- a/sepolicy/qcom/bootanim.te
+++ b/sepolicy/qcom/bootanim.te
@@ -1,0 +1,8 @@
+allow bootanim mpctl_socket:dir search;
+unix_socket_connect(bootanim, mpctl, perfd)
+unix_socket_send(bootanim, mpctl, perfd)
+
+allow bootanim mpdecision:dir search;
+allow bootanim mpdecision:file r_file_perms;
+unix_socket_connect(bootanim, mpctl, mpdecision)
+unix_socket_send(bootanim, mpctl, mpdecision)

--- a/sepolicy/qcom/device.te
+++ b/sepolicy/qcom/device.te
@@ -1,0 +1,1 @@
+type persist_block_device, dev_type;

--- a/sepolicy/qcom/domain.te
+++ b/sepolicy/qcom/domain.te
@@ -1,0 +1,2 @@
+allow domain persist_file:dir getattr;
+allow domain persist_block_device:blk_file getattr;

--- a/sepolicy/qcom/mpdecision.te
+++ b/sepolicy/qcom/mpdecision.te
@@ -1,0 +1,5 @@
+allow mpdecision sysfs_devices_system_iosched:file rw_file_perms;
+unix_socket_connect(mpdecision, thermal, thermal-engine)
+
+# read /proc/pid files
+r_dir_file(mpdecision, domain)

--- a/sepolicy/qcom/perfd.te
+++ b/sepolicy/qcom/perfd.te
@@ -1,0 +1,7 @@
+allow perfd sysfs_devices_system_iosched:file rw_file_perms;
+
+# read mediaserver status
+allow perfd mediaserver:file { read open };
+
+#cm extra opts
+unix_socket_connect(perfd, thermal, thermal-engine)

--- a/sepolicy/qcom/perfprofd.te
+++ b/sepolicy/qcom/perfprofd.te
@@ -1,0 +1,5 @@
+# perfprofd disables mpdecision temporarily via setprop ctl.stop,
+# then re-enables afterwards with setprop ctl.start
+userdebug_or_eng(`
+  set_prop(perfprofd, mpdecision_prop)
+')

--- a/sepolicy/qcom/sepolicy.mk
+++ b/sepolicy/qcom/sepolicy.mk
@@ -1,0 +1,2 @@
+BOARD_SEPOLICY_DIRS += \
+    vendor/cm/sepolicy/qcom

--- a/sepolicy/qcom/system_server.te
+++ b/sepolicy/qcom/system_server.te
@@ -1,0 +1,10 @@
+# LiveDisplay access to color calibration
+allow system_server pps_socket:sock_file rw_file_perms;
+allow system_server mm-pp-daemon:unix_stream_socket connectto;
+
+# Time services
+allow system_server time_daemon:unix_stream_socket connectto;
+
+#allow reading of usb sysfs to query hvdcp state
+allow system_server sysfs_usb_supply:dir { search };
+allow system_server sysfs_usb_supply:file r_file_perms;

--- a/sepolicy/qcom/thermal-engine.te
+++ b/sepolicy/qcom/thermal-engine.te
@@ -1,0 +1,7 @@
+allow thermal-engine self:netlink_kobject_uevent_socket create_socket_perms;
+r_dir_file(thermal-engine, sysfs_rqstats);
+
+allow thermal-engine sysfs_battery_supply:file rw_file_perms;
+allow thermal-engine sysfs_battery_supply:dir r_dir_perms;
+
+allow thermal-engine self:capability { net_admin } ;

--- a/sepolicy/qcom/vold.te
+++ b/sepolicy/qcom/vold.te
@@ -1,0 +1,1 @@
+allow vold persist_file:dir { getattr read open ioctl };

--- a/sepolicy/recovery.te
+++ b/sepolicy/recovery.te
@@ -23,6 +23,8 @@ allow recovery media_rw_data_file:dir r_dir_perms;
 allow recovery media_rw_data_file:file r_file_perms;
 allow recovery vfat:dir r_dir_perms;
 allow recovery vfat:file r_file_perms;
+allow recovery sdcard_posix:dir r_dir_perms;
+allow recovery sdcard_posix:file r_file_perms;
 
 # Control properties
 allow recovery recovery_prop:property_service set;

--- a/sepolicy/seapp_contexts
+++ b/sepolicy/seapp_contexts
@@ -1,1 +1,2 @@
 user=theme_man domain=system_app type=system_data_file
+user=_app seinfo=cmupdater name=com.cyanogenmod.updater domain=system_app type=system_app_data_file

--- a/sepolicy/service.te
+++ b/sepolicy/service.te
@@ -1,3 +1,11 @@
 type edge_gesture_service, system_api_service, system_server_service, service_manager_type;
 type themes_service, system_api_service, system_server_service, service_manager_type;
 type torch_service, system_api_service, system_server_service, service_manager_type;
+type kill_switch_service, system_api_service, system_server_service, service_manager_type;
+type cm_status_bar_service, system_api_service, system_server_service, service_manager_type;
+type cm_profile_service, system_api_service, system_server_service, service_manager_type;
+type cm_partner_interface, system_api_service, system_server_service, service_manager_type;
+type cm_telephony_service, system_api_service, system_server_service, service_manager_type;
+type cm_hardware_service, system_api_service, system_server_service, service_manager_type;
+type cm_app_suggest_service, system_api_service, system_server_service, service_manager_type;
+type cm_performance_service, system_api_service, system_server_service, service_manager_type;

--- a/sepolicy/service_contexts
+++ b/sepolicy/service_contexts
@@ -1,3 +1,11 @@
 edgegestureservice                        u:object_r:edge_gesture_service:s0
 themes                                    u:object_r:themes_service:s0
 torch                                     u:object_r:torch_service:s0
+killswitch                                u:object_r:kill_switch_service:s0
+cmstatusbar                               u:object_r:cm_status_bar_service:s0
+profile                                   u:object_r:cm_profile_service:s0
+cmpartnerinterface                        u:object_r:cm_partner_interface:s0
+cmtelephonymanager                        u:object_r:cm_telephony_service:s0
+cmhardware                                u:object_r:cm_hardware_service:s0
+cmappsuggest                              u:object_r:cm_app_suggest_service:s0
+cmperformance                             u:object_r:cm_performance_service:s0

--- a/sepolicy/shell.te
+++ b/sepolicy/shell.te
@@ -1,1 +1,0 @@
-allow shell adbtcp_prop:property_service set;

--- a/sepolicy/system.te
+++ b/sepolicy/system.te
@@ -11,6 +11,3 @@ allow system_server theme_data_file:dir create_dir_perms;
 allow system_server theme_data_file:file create_file_perms;
 allow system_server resourcecache_data_file:dir create_dir_perms;
 allow system_server resourcecache_data_file:file create_file_perms;
-
-# System server dynamically loads some dexfiles
-allow system_server dex2oat_exec:file rx_file_perms;

--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -4,3 +4,5 @@ allow system_server recovery_cache_file:file create_file_perms;
 # Persistent properties
 allow system_server persist_property_file:dir rw_dir_perms;
 allow system_server persist_property_file:file { create_file_perms unlink };
+
+allow system_server storage_stub_file:dir { getattr };

--- a/sepolicy/vold.te
+++ b/sepolicy/vold.te
@@ -13,4 +13,10 @@ allow vold self:capability { setgid setuid };
 # Vold can also run as minivold in the rootfs
 recovery_only(`
   allow vold rootfs:dir { add_name write };
+  allow vold rootfs:file execute_no_trans;
 ')
+
+# External storage
+allow vold storage_stub_file:dir { rw_file_perms search add_name };
+allow vold mnt_media_rw_stub_file:dir r_dir_perms;
+allow vold mkfs_exec:file { execute read open execute_no_trans };


### PR DESCRIPTION
Remove our sepolicy

Change-Id: Icb4656f737d24000dd549eaa0713f224bbc5d29f

selinux: Add CM-specific file_contexts

Change-Id: Ie70c59acedbb7be2f5b34a83c1d3d011f440ba05

selinux: Add missing seapp_contexts file

Change-Id: I6bda9e4876b9053ea16fe3c11c21b9c1e7acb17a

sepolicy: f2fs: Allow fs_use_xattr

Change-Id: I458d464598777fa06751dad0aa9cfd4d903a4de1

selinux: Fix asec mounting

Change-Id: I92392f3d810dfaf8dfc35f5c9170178a651d28dc

sepolicy: treat fuseblk as sdcard_external

Allow fuse-mounted NTFS/exFAT file systems to be written to

Change-Id: I1492914dd269a305e27aba58e61064d853adf2bc

sepolicy: allow installd to query ASEC size

installd need to query ASEC size on sdcard_external
to show on the Settings -> Apps page correctly.

Change-Id: I2d9a49b8f0652f05d73d0ff464a3835595e2cc3c

sepolicy: allow vold to create files on external sdcard

This is required for ASEC support. Vold can already create and
access directories, but do not yet have the permission for files.

Change-Id: I5082bbff692e5dc53c7000e4b3a293e42d33f901

sepolicy: allow vold to mount ext4 sdcard

When vold mounts an ext4 sdcard, it needs to force the context to
sdcard_external.

avc:  denied  { relabelfrom } for  pid=190 comm=vold scontext=u:r:vold:s0 tcontext=u:object_r:labeledfs:s0 tclass=filesystem
avc:  denied  { relabelto } for  pid=190 comm=vold scontext=u:r:vold:s0 tcontext=u:object_r:sdcard_external:s0 tclass=filesystem
avc:  denied  { relabelfrom } for  pid=190 comm=vold scontext=u:r:vold:s0 tcontext=u:object_r:sdcard_external:s0 tclass=filesystem

Change-Id: I80f42fbdf738dee10958ce1bdc1893a41234f0d9

sepolicy: allow vold to mount fuse-based sdcard

exfat and NTFS-3g requires access to /dev/fuse

Change-Id: I35b13ada586c8de3fbe04156c2d10bf5e3c07b3a

cm: sepolicy: Allow ueventd to properly handle cpufreq changes

 * We need to allow relabeling since these files can pop in and out if
   the governor is changed.

Change-Id: Id75099290e24dac9962d4fed8148ec2df9e256b2

cm: sepolicy: Allow ueventd to load WiFi and audio irmware

 * Every device which uses Prima or WCD will hit this, so just allow it.

Change-Id: Ie2303ad7fc3498276d41e567a738cd016f635453

cm: policy for ipv6 tethering

 * Enable use of radish via netd for ipv6 tethering

Change-Id: Ifa0e85686fc70f59c089ca40a78cea9935820185

sepolicy: Allow relabeling after wallpaper change

Change-Id: I89220fae961f483dad8b92faaee9ed8fe6c8a7cf

Updates for CM12

Change-Id: I33d6db738c53c713a2885ce5e8ee692badd91070

selinux: Add rules for the audit daemon

Change-Id: I050a9ef39d58d2592d880d225d45eb64d8a40b7b

[1/2] SEPolicy: Add Edgegesture service.

Change-Id: Id9fc2d68b954e1cd6792739309a0df40e2dc998c

vendor: Update SELinux policy for sysinit

Change-Id: I41d4c25d9d6246cd2ca0a8ff3b5a4e114e3bc4d4

Add selinux policies for superuser

Change-Id: I878eaa9d25feaedf46e89083f91d6a21f4aff37a

selinux: Add a rule to label the extended keyhandler dex files

These should be treated as regular dex cache files, but they're
expanded outside of the normal cache dir

Change-Id: Id046e1b90116b35d2e7817ed4717fcef78135f08

selinux: Fix healthd's access to /dev nodes

Our healthd's support for power-on alarms adds some steps that imply
reading files its user doesn't own. Let it.

Change-Id: I3d4735aaab8fbec7acc460f812bc21f1dfa516ab

cm: sepolicy: Add contexts for cm recovery

 * Allow setup of secure adb (setup_adbd)

 * minivold in recovery

Change-Id: Id1243154f4016b59e54890404cadea46a2aad212

Allow SystemServer to set service.adb.tcp.* properties

Required for network adb enable/disable to function

Change-Id: I3e2aacb6b8e9b107dcd229187a5dd76128e20001

SELinux: su: Remove extra quote in a comment

* Fixes
  vendor/cm/sepolicy/su.te:46:WARNING 'unrecognized character' at token '''

Change-Id: I3957ba7ac05062766cbf6c8f3c3975f20c95532e

vendor: add policies for netd

Required due to CAF's abc9c0f4fe574ee9847f118e5d2ae8c530bac650 in
system/netd

Fixes showing how many devices are connected to the tethered hotspot

Change-Id: I1d83f7ac0b28efa6973e0baf429de2a398c471e3

sepolicy: Fix permissions for service.adb.tcp.port

This makes the rule more specific by overriding the upstream sepolicy.
Also adds the adbd context which is necessary for "adb tcpip".

Change-Id: Ia17eb56fc1682ab248764329e88eebd2a4075c97

SELinux: su: update policies

- Integrate policies from domain.te (fixes ES File Manager which uses unix socket)
- Allow platform_app to use su (fixes CM File Manager)

Change-Id: I39dd55e63b44590575bbe6d889c8d77141ba8545

sepolicy: More rules for recovery

Change-Id: Ie50c04eb83cb9c62f679a1c1aa2ac482af159f7e

Revert "SELinux: su: update policies"

This reverts commit 04fd9192b05ae2655560a444711fe8859430f439.

Change-Id: I69e51fb6c151a48972cf81947c1c59c6f26f60e9

selinux: Workaround for devices with PR_SET_NO_NEW_PRIVS enforcement

PR_SET_NO_NEW_PRIVS blocks domain transitions from within app_process,
unless the new domain is bounded by the app's context. So we can't
switch to a domain that has perms not available to untrusted_app :(

This means any app can talk to the daemon, bypassing the su executable
client. That's not a good thing, and needs to be resolved.

Change-Id: I85b74f90b8737caaa193a0555b5262e7392519b2

cm: add sepolicy entry for lockscreen wallpaper

Change-Id: Ie779392ab8118d192873a01ec5c7de3e5938ed17
Signed-off-by: Roman Birg <roman@cyngn.com>

Sepolicy: Add theme service as system service

Change-Id: Idfb690be5d35c03610165b914c0a3f2260e68956

cm: sepolicy: Remove vold external sdcard rules, moved to main sepolicy

Change-Id: I67756bad2c6e1361ecc0052003f2b4e5e4dbb007

selinux: Downgrade CMFM's domain

the filemanager doesn't need to be in platform_app. Put it in untrusted_app,
especially since it's a possible su client

Change-Id: I164853f2c8721d86b5b90677cb33032a3b491ff5

sepolicy: allow recovery read access to /data/media/ files and dirs

Change-Id: I41173d72e86f9cf4d79f7c46166eeb71dc19d2f4

selinux: New rw privileges for themes

- New theme_data_file context for files under /data/system/theme
- Permit systemserver to create files/dirs under /data/resource-cache
- Permit systemserver to create files/dirs under /data/system/theme

Change-Id: Id597fc20b477ea395a8631623f26a7edde280799

sepolicy: remove stray + in type statement

Change-Id: Ic34c9ae32658541064a63153612145c6fd3d55b3

cm: Remove KSM permissions

CM12 doesn't have a KSM setting in performance settings anymore.
KSM should be configured and enabled on device basis.

Change-Id: I98a0cbe1b01a659eb28bcd459be55d78a88bda86

selinux: Allow recovery to do recursive deletes

Our partial wipes (preserving media) require that recovery can
rmdir dirs and getattr files

Change-Id: I206f74131f9a37c5887ef30062adeabb58beaa3a

cm: sepolicy: fix performance settings

Change-Id: Idea17856b4aef9258688a3ad58d0e5cac6d805a6

sepolicy: Add policies for the new superuser sockets.

Change-Id: Ia3e1044616bee95eb4774254fb098487d983b5db

sepolicy: new label for io scheduler sysfs nodes

* needed for io scheduler in performance settings

Change-Id: I818340ed62e3e1dd2674b93340b31723c7a985f4

sepolicy: Apps need to read themed resources

Assets such as composed icons and ringtones need to be accessed
by apps.  This patch adds the policy needed to facilitate this.

Change-Id: If47920b2cc5dbafe8d71a621782bb4a3351bd68c

sepolicy: Additional filesystem perms for recovery

Change-Id: I66c785de7256ea64302a258af7c33cb717530343

cm: sepolicy: Allow use of dexclassloader by systemserver

 * Needed for custom keyhandler.

Change-Id: Ifa57ad81951f9e1009eb291726cd8dfe36a3482e

sepolicy: Allow cmupdater/uncrypt access to media_rw_data_file

Change-Id: I800584af2919e3397b19d229fc28ad50cc4b2730

sepolicy: Fix policy for keyhandler

Change-Id: I2860f469480b082511e30530aed8a9027e9fe4b9

sepolicy: Let drmserver scan themes

Change-Id: I7675b302723ef8700067ae9ef237daf6346a6627

cm: add torch service sepolicy entry

Change-Id: I6e6feae5fe6b4092c137ee2337c4a15b390df45e
Signed-off-by: Roman Birg <roman@cyngn.com>

sepolicy: actually include mediaserver.te

Added in patch e9c2de0679f16a8ba7291aaf2cd4286bef8b2886 but not included

Change-Id: I2ae901a7c80fceb33dba2ed4122d2aa47bff5a51

sepolicy: allow userinit to set its property

Change-Id: I9d8270d889566d169077a1b1fdaee43059d11ee1

sepolicy: Split off /cache/recovery's permissions

/cache/recovery is used by 2 domains: recovery and updater apps. Separate
its perms from the rest of /cache and grant them to those 2 clients

Change-Id: Iacde60744c07423f9876c2f8e3da900543e38ddf

sepolicy: Fix denails for flash_recovery service

Needed when option is checked to update cm recovery

Change-Id: I0b2fbfd7c141ae03ce14b9afeffd3a027d791c80

sepolicy: Allow system apps to write cache and media files

Updaters need to be able to read and write to these locations.

Change-Id: I928a5f73ec29ab4fecb717072532d449192f3ca9

sepolicy: Allow vold to create tmpfs files for asec containers

Change-Id: Ic8f1641928840774204099453b74dc1b52b3c6f8

sepolicy: Allow CMUpdater/uncrypt access to recovery_cache_file

Change-Id: I514d128160ed4e04564077d7a2e2ad297af92e28

[3/3] CmHardwareService: add sepolicy

Change-Id: I551f61f40225a679593e94dbd47bb2fb0025da7e

sepolicy: recovery: Allow data file write

Needed to preserve /data/.layout_version (aka nesting bug fix).

Change-Id: Iaae982223e80ad10479cf1ca3db09da7ada5663e

sepolicy: Permissions for userinit

Change-Id: Icaf9d191841a6214925729e40d84a61a2ebf2296

vendor: add sepolicy entry for killswitch service

Change-Id: Ib3c44c50138f5715d92addbf8df7ed591785b550
Signed-off-by: Roman Birg <roman@cyngn.com>
(cherry picked from commit 2ca5d3999b35d328f0969a264009bffe0faf889d)

Build CM Platform Library

Change-Id: If62e6b1d2ac41730ff2a8d562173abd2cb768f93

Add cmstatusbar service to system server services context

Change-Id: I77c5de75722cc5f36a5326e3da57ab661b89d189

Build Platform resource package.

Change-Id: Id60f66b6db23989db1472a19bcb079b0083f7393

vendor/cm: Lock cm platform library/cmsdk to non-release builds.

Change-Id: I01c1c3fe559d438e28339ce426d7ba7e42724002

vendor/cm: overlay start for ProfileService in external framework.

Change-Id: Ib1f8c6d00c2a66cfd8dac2b73ccd1bd053a3a497

sepolicy: system_app: Remove performace setting related entries

* Performance Settings has been removed/refactored so these are no longer neccessary.

Change-Id: I5933700815d0037735fc48f8640b37d1f350ea91
Signed-off-by: Brandon McAnsh <brandon.mcansh@gmail.com>

sepolicy: Allow recovery to set system properties

 * This is used by extremely critical things.

Change-Id: Ie529851469408adac1e081fe4f6dc5daa9002933

Add SettingsManagerService from cmsdk as a system service.

Change-Id: I0909a5fd49e8e042293719de93ebc8fbaaa1a196

cmsdk: Dual SIM support on CM SDK

Change-Id: I209245e1a3165f329ed8a17a942340d96783ca13

cm: Moving CMHW to CMSDK

Change-Id: I4dae95dbe68c472ba3703fea588b542758ec8036

cm: SELinux policy for persistent properties API

 * Set up persistent properties for devices with a /persist partition.

Change-Id: I78974dd4e25831338462c91fc25e36e343795510

vendor/cm: cmsettings -> cmpartnerinterface

Change-Id: I9d9b30da37f243f77647c6d41cf0e0159968b8e2

Enable The AppSuggestService

We need to enable our custom AppSuggestService in order to show
possible suggestions.

Change-Id: I9489723dfec315c7ff4ab414ebe88c3880876bd3

cm: sepolicy: Create standard policy for LiveDisplay

Change-Id: Icb0047f261861c8fae99ffa4e9053de8d3aa8c73

cm: sepolicy: Create central place for QC-specific policy

 * We have a number of policy items due to changes in our BSPs or for
   other things which interact with the QC sepolicy. Add a place
   for us to store this stuff so we don't need to copy it around to
   every device.

Change-Id: I155ca202694501d42b42e2bd703d74049d547df0

cm: Fix a few denials

 * Missed a few things when cleaning up devices.

Change-Id: Ib71afd696a564aeeaa80c34ca9744a39891f4b63

sepolicy: Allow system app to set boot anim property

Addresses denials observerd when using QuickBoot:

<4>[  224.756971] avc:  denied  { set } for property=ctl.bootanim scontext=u:r:system_app:s0 tcontext=u:object_r:ctl_bootanim_prop:s0 tclass=property_service
<3>[  224.757094] init: sys_prop: Unable to start service ctl [bootanim] uid:1000 gid:1000 pid:6039
<4>[  226.306456] avc:  denied  { set } for property=ctl.bootanim scontext=u:r:system_app:s0 tcontext=u:object_r:ctl_bootanim_prop:s0 tclass=property_service

Change-Id: I338a0a1d5fa12c10e413769ea9638c10ed137000

sepolicy: allow vold to trim persist

Change-Id: I6441c00bfd173f1f3fd4c09a67c678c5bd4f8090
Issue-id: SYSTEMS-62

sepolicy: Underp the context for persistent storage

The dir's context need love, too

TICKET: CYNGNOS-1185
Change-Id: I659b3ba06079825fe850cf66858a9d98b5f61c46

sepolicy: remove BOARD_SEPOLICY_UNION

* this is a no-op now

Change-Id: I3703a9670285017ce7aec9ac20c63a6f733b8ffa

vendor/cm: Fix up service contexts for sepolicy.

Change-Id: Ibb04e967bd027c6d1118b8b471ec328c3b034d9d

sepolicy: remove sudaemon type declaration

* this is already defined in external/sepolicy

Change-Id: I541b5de5bb6057f4fa3d88b6e9b9425b65f9963e

cm: Remove duplicate SEPolicy items

 * These are handled by the master SEPolicy now due to neverallow
   exceptions which occur on non-production builds.

Change-Id: Id50d9e41e1c8b0b1f26df7921def9e7a201f49d9

perf: Moving PerformanceManager to CMSDK

 * Devices will need to update their configurations!

Change-Id: I22cf4ec96656b98f515cf28fef95443cf6adb397

sepolicy: Make superuser_device and sudaemon mlstrustedobjects

Address:
avc: denied { write } for pid=8782 comm="su" name="su-daemon" dev="tmpfs" ino=9462
scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:superuser_device:s0
tclass=sock_file permissive=0

avc: denied { connectto } for pid=6666 comm="su" path="/dev/socket/su-daemon/su-daemon"
scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:r:sudaemon:s0
tclass=unix_stream_socket permissive=0

And thus fix su.

Change-Id: I666277067c5ff9f2a985c243075c63fd87090b27

sepolicy: qcom: Remove duplicate entry

We have this in qcom/sepolicy/common already.

Change-Id: Ibe6ada531f77d3ec00ff61081d21b3d36a1fe7a7

sepolicy: Add policy for thermal engine changes

 * Cyngn devices will need this.

Change-Id: I1e7528e92d0d4ed8c4029667d7ef3cf9081a6575

sepolicy: Remove some denials

 * Allow apps to run the "df" command to look at disk usage.
 * Allow thermal engine to check/set battery limits.

Change-Id: I67c863a82a94007e7a5e8ccfde9c095b7277ab84

sepolicy: add persist_block_device type

* This is likely defined in several device trees, but not all
  remove it from your device trees if we're going to write rules
  for it here.

Change-Id: I1dda04647d36db52525a3d57b485860dfe3eeb30

sepolicy: fix denial for sudaemon

fixes root access for apps

Change-Id: Iff443bf4cbea817917da72bbfc58f9fe42acceb5

sepolicy: Rule for CM's perfd extension

Manual apply and refactor of cm-12.1 patch:
e04329df88211264e7a9c8f1d6b87a16d8d5639b

Use the unix_socket_connect macro and switch to the new
perfd domain.

Change-Id: Ibb83220b32bad7805653140751c978e629f87ffb

sepolicy: Allow recovery to create links in the rootfs

 * Needed to support vold and other new code.

Change-Id: I25a0b1cc6461eced7112dd4b3974a71423f7957b

sepolicy: qcom: Allow reading PSU sysfs by system_server

BatteryService queries the usb state to check whether the usb type
is HVDCP. This patch adds a rule to allow that.

For more context check BatteryService#Led#isHvdcpPresent.

Change-Id: Ifacf13dde4b1df81c92bf5d92196e504e61dd402

sepolicy: Allow adb pull of executables without root

 * Because we aren't actually jerks, contrary to popular belief.

Change-Id: Ie39cce65ecc6a2861547865ff554b108b8b534fa

sepolicy: Add domain for mkfs binaries

The init binary must transition to another domain when calling out to
executables. Create the mkfs domain for mkfs.f2fs such that init can
transition to it when formatting userdata/cache partitions if the
"formattable" flag is set.

Change-Id: I1046782386d171a59b1a3c5441ed265dc0824977

sepolicy: Add permission for formatting user/cache partition

If the "formattable" fstab flag is set, init will tries
to format that partition, added the required policy to allow it.

Change-Id: I858b06aa3ff3ce775cf7676b09b9960f2558f7f6

SELinux: Use custom ADB over network property

* Use a custom system property to trigger the real one, so we avoid
  running afoul of any SELinux CTS requirements.

Change-Id: If5e7a275f492631a673284408f1e430a12358380

sepolicy: Set the context for fsck.exfat/ntfs to fsck_exec

This matches the policy for fsck.f2fs, although it still needs to run
as fsck_untrusted for public volumes

Change-Id: Ia04e7f8902e53a9926a87f0c99e603611cc39c5d

sepolicy: label exfat and ntfs mkfs executables

Change-Id: Ic5e32818bc54993f4e8c2377cbec64f9444f6d8a

cm: sepolicy: fix denials for external storage

Change-Id: I784a859671c69370cab0118a88a5fb0190352af9

sepolicy: Allow minivold execute_no_trans

After assimilating minivold into /sbin/recovery, we need to allow the
minivold service (a symlink to the recovery binary) to transition from
the recovery to the vold domain.

Change-Id: I112e6d371a8da8fc55a06967852c869105190616

sepolicy: Add perfprofd with set_prop macro

Addresses:
avc: denied { write }
for pid=293 comm="perfprofd" name="property_service" dev="tmpfs" ino=9229 scontext=u:r:perfprofd:s0 tcontext=u:object_r:property_socket:s0 tclass=sock_file permissive=0

Change-Id: I5a88722eda4d0751fd9a081c434d385ac1c785ef